### PR TITLE
Chore: Docs and templates setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature.md
+++ b/.github/ISSUE_TEMPLATE/1-feature.md
@@ -1,0 +1,26 @@
+---
+name: ✨ Feature request
+about: Template for requesting new features
+title: ''
+labels: 'Type: Feature'
+assignees: ''
+---
+
+## 📄 Context
+
+What is the problem that you are trying to solve?
+Why is this problem relevant?
+
+## ✔️ Solution
+
+(This section and the ones below are optional.)
+What are the possible solutions?
+If there are multiple, what are the benefits and drawbacks of each one?
+
+## 📈 Subtasks
+
+- [ ] If there is a solution, what are the subtasks for completing this issue?
+
+## 🎯 Definition of Done
+
+- [ ] If there is a solution, what are the final deliverables?

--- a/.github/ISSUE_TEMPLATE/2-technical-debt.md
+++ b/.github/ISSUE_TEMPLATE/2-technical-debt.md
@@ -1,0 +1,28 @@
+---
+name: 🏗️ Technical Debt
+about: Template for proposing solutions to technical debts
+title: ''
+labels: 'Type: Refactor'
+assignees: ''
+---
+
+## 📄 Context
+
+What is the problem that you are trying to solve?
+Why is this problem relevant?
+How this problem afects the feature roadmap?
+Is it a blocker to implement a new feature?
+What parts of the architecture and/or code are affected?
+
+## ✔️ Solution
+
+What are the possible solutions?
+If there are multiple, what are the benefits and drawbacks of each one?
+
+## 📈 Subtasks
+
+- [ ] What are the subtasks for completing this issue?
+
+## 🎯 Definition of Done
+
+- [ ] What are the final deliverables?

--- a/.github/ISSUE_TEMPLATE/3-update-dependencies.md
+++ b/.github/ISSUE_TEMPLATE/3-update-dependencies.md
@@ -1,0 +1,20 @@
+---
+name: ⬆️ Update Dependencies
+about: Template for updating dependencies
+title: ''
+labels: 'Type: Chore'
+assignees: ''
+---
+
+## 📄 Context
+
+Please provide a clean and concise description of what dependency/dependencies will be updated and the expected impacts.
+What are the dependency or dependencies to be updated?
+What are the parts of the code that will be affected by this action?
+Why is that update relevant?
+
+## 📈 Subtasks
+
+- [ ] If an update requires major work, create the corresponding issue.
+- [ ] Make sure dependencies are updated in the lock file (package-lock.json).
+- [ ] Verify whether everything is working as expected.

--- a/.github/ISSUE_TEMPLATE/4-documentation.md
+++ b/.github/ISSUE_TEMPLATE/4-documentation.md
@@ -1,0 +1,27 @@
+---
+name: '📖 Documentation issue'
+about: Help improve our docs.
+labels: 'Type: Documentation'
+---
+
+### Documentation issue
+
+<!-- (Update "[ ]" to "[x]" to check a box) -->
+
+- [ ] Reporting a typo
+- [ ] Reporting a documentation bug
+- [ ] Documentation improvement
+- [ ] Documentation feedback
+
+<!--
+  If your issue is not regarding the documentation, please choose an issue type:
+  https://github.com/cartesi/rollups-squid/issues/new/choose
+-->
+
+### Is there a specific documentation page you are reporting?
+
+Enter the URL or documentation section here.
+
+### Additional context or description
+
+Provide any additional details here as needed.

--- a/.github/ISSUE_TEMPLATE/5-bug.md
+++ b/.github/ISSUE_TEMPLATE/5-bug.md
@@ -1,0 +1,31 @@
+---
+name: 🐛 Bug Report
+about: Template for bug report
+title: ''
+labels: 'Type: Bug'
+assignees: ''
+---
+
+## 🙂 Expected behavior
+
+What is expected to happen?
+
+## 🫠 Actual behavior
+
+What is happening instead?
+
+## 🧪 Minimal test case
+
+Please describe a minimal test case that demonstrates the bug.
+If possible, this should be an automated test.
+
+## 🌎 Environment
+
+What is the network that the bug happens? e.g Mainnet / Sepolia / Local
+What is the Rollups and/or Rollups-squid version?
+
+## ✔️ Possible solutions
+
+(This section is optional.)
+Any hint on how to solve the issue?
+What parts of the code will be affected?

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,14 @@
     "trailingComma": "all",
     "printWidth": 80,
     "tabWidth": 4,
-    "arrowParens": "always"
+    "arrowParens": "always",
+    "overrides": [
+        {
+            "files": "*.md",
+            "options": {
+                "tabWidth": 1,
+                "bracketSpacing": false
+            }
+        }
+    ]
 }

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Bruno Menezes <brunodmenezes@gmail.com>
+Danilo Tuler <tuler@pobox.com>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+-   Using welcoming and inclusive language
+-   Being respectful of differing viewpoints and experiences
+-   Gracefully accepting constructive criticism
+-   Focusing on what is best for the community
+-   Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+-   The use of sexualized language or imagery and unwelcome sexual attention or
+    advances
+-   Trolling, insulting/derogatory comments, and personal or political attacks
+-   Public or private harassment
+-   Publishing others' private information, such as a physical or electronic
+    address, without explicit permission
+-   Other conduct which could reasonably be considered inappropriate in a
+    professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [Explorer Discord channel](https://discord.com/channels/600597137524391947/1108079755649110166). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to Cartesi
+
+Thank you for your interest in Cartesi! We highly appreciate even the smallest of fixes or additions to our project.
+
+Make sure to review our [Contributing License Agreement](https://forms.gle/k3E9ZNkZY6Vy3mkK9),
+sign and send it to info@cartesi.io with the title of "CLA Signed" before taking part in the project. We are happy to automate
+this for you via DocuSign upon request in the Google Form as well.
+
+## Basic Contributing Guidelines
+
+We use the same guidelines for contributing code to any of our repositories, any developers wanting to contribute to Cartesi must create pull requests. This process is described in the [GitHub documentation](https://help.github.com/en/articles/creating-a-pull-request). Each pull request should be started against the master branch in the respective Cartesi repository. After a pull request is submitted the Cartesi team will review the submission and give feedback via the comments section of the pull request. After the submission is reviewed and approved, it will be merged into the master branch of the source.
+
+Please note the below! We appreciate everyone following the guidelines.
+
+-   No --force pushes or modifying the Git history in any way;
+-   Use non-main branches, using a short meaningful description, with words separated by dash (e.g. 'fix/this-bug');
+-   Abide by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/);
+-   All modifications must be made in a pull-request to solicit feedback from other contributors.
+
+## Get in Touch
+
+When contributing in a deeper manner to this repository, please first discuss the change you wish to make via our
+[Discord channel here](https://discord.gg/Pt2NrnS) before working on the change.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2023 Bruno Menezes
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+      Copyright Cartesi and individual authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "squiddy",
+  "name": "@cartesi/rollups-explorer-api",
   "version": "0.1.0",
   "private": true,
+  "license": "Apache-2.0",
   "scripts": {
     "build": "run-s clean sqd:typegen sqd:codegen tsc",
     "clean": "rm -rf lib",

--- a/squid-mainnet.yaml
+++ b/squid-mainnet.yaml
@@ -1,7 +1,7 @@
 manifestVersion: subsquid.io/v0.1
-name: rollups-mainnet
-version: 6
-description: 'Indexing Cartesi Rollups contracts'
+name: cartesi-rollups-mainnet
+version: 1
+description: 'Indexing Cartesi Rollups contracts on Mainnet'
 build:
 deploy:
     addons:

--- a/squid-sepolia.yaml
+++ b/squid-sepolia.yaml
@@ -1,7 +1,7 @@
 manifestVersion: subsquid.io/v0.1
-name: rollups-sepolia
-version: 6
-description: 'Indexing Cartesi Rollups contracts'
+name: cartesi-rollups-sepolia
+version: 1
+description: 'Indexing Cartesi Rollups contracts on Sepolia'
 build:
 deploy:
     addons:


### PR DESCRIPTION
### Summary
Adding necessary things before moving this repo under Cartesi repositories

Changes:
* Add docs for License, code of conduct, contributing. 
* Add GitHub issue templates. 
* Update squid manifest to have the namespace `cartesi*`.